### PR TITLE
Updated Dockerfile to properly use ENTRYPOINT and CMD instructions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,6 @@ RUN chmod +x /run.sh
 
 EXPOSE 8022
 
-CMD ["/run.sh"]
+ENTRYPOINT ["gateone"]
+
+CMD ["--log_file_prefix=/gateone/logs/gateone.log"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,9 +48,6 @@ RUN rm -f /etc/gateone/ssl/key.pem && \
     rm -f /gateone/logs/* 
 # (We don't want everyone using the same SSL key/certificate)
 
-COPY run.sh /run.sh
-RUN chmod +x /run.sh
-
 EXPOSE 8022
 
 ENTRYPOINT ["gateone"]

--- a/run.sh
+++ b/run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-cd /gateone/GateOne
-gateone --log_file_prefix=/gateone/logs/gateone.log


### PR DESCRIPTION
Removed run.sh file since all it did was launch the gateone executable which we're now doing via Dockerfile